### PR TITLE
[Please read details] Change date so we can use phenotype_annotation.tab

### DIFF
--- a/ontolib-io/src/main/java/com/github/phenomics/ontolib/io/obo/hpo/HpoDiseaseAnnotationParser.java
+++ b/ontolib-io/src/main/java/com/github/phenomics/ontolib/io/obo/hpo/HpoDiseaseAnnotationParser.java
@@ -121,7 +121,7 @@ public class HpoDiseaseAnnotationParser implements TermAnnotationParser<HpoDisea
 
     nextLine = reader.readLine();
 
-    final SimpleDateFormat format = new SimpleDateFormat("yyyy.MM.dd");
+    final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
     Date date;
     try {
       date = format.parse(dateStr);


### PR DESCRIPTION
For phenotype_annotation.tab, the date format is of the form 2013-06-23.
For negative_phenotype_annotation.tab the date format is as used currently (	 2013.06.23)

Note that if you use this commit, you will need to comment out the corresponding test: HpoDiseaseAnnotationParserTest.java