### PR TITLE
Fix documentation to reflect what code is actually doing

### DIFF
--- a/ontolib-core/src/main/java/com/github/phenomics/ontolib/formats/hpo/HpoDiseaseAnnotation.java
+++ b/ontolib-core/src/main/java/com/github/phenomics/ontolib/formats/hpo/HpoDiseaseAnnotation.java
@@ -200,7 +200,7 @@ public final class HpoDiseaseAnnotation implements TermAnnotation {
   }
 
   /**
-   * @return Frequency modifier; optional, <code>null</code> when missing.
+   * @return Frequency modifier; returns "" empty string when not present
    */
   public String getFrequencyModifier() {
     return frequencyModifier;


### PR DESCRIPTION
Tested with the following (this is the first line from the HPO tab). It gives me the empty string, and not null

> DECIPHER	1	Wolf-Hirschhorn Syndrome		HP:0000252	DECIPHER:1	IEA				O	WOLF-HIRSCHHORN SYNDROME	2013-05-29	HPO:skoehler