### PR TITLE
Subontology

### DIFF
--- a/ontolib-core/src/main/java/com/github/phenomics/ontolib/ontology/data/ImmutableOntology.java
+++ b/ontolib-core/src/main/java/com/github/phenomics/ontolib/ontology/data/ImmutableOntology.java
@@ -207,8 +207,15 @@ public class ImmutableOntology<T extends Term, R extends TermRelation> implement
         relationBuilder.put(entry.getKey(),entry.getValue());
       }
     }
-    return new ImmutableOntology<T, R>(metaInfo, subGraph, subOntologyRoot,
-      intersectingTerms,
+    // Note: natural order returns a builder whose keys are ordered by their natural ordering.
+    final ImmutableSortedMap.Builder<String,String> metaInfoBuilder = ImmutableSortedMap.naturalOrder();
+    for (String key : metaInfo.keySet()) {
+      metaInfoBuilder.put(key,metaInfo.get(key));
+    }
+    metaInfoBuilder.put("provenance",String.format("Ontology created as a subset from original ontology with root %s",getTermMap().get(rootTermId).getName() ));
+    ImmutableSortedMap<String,String> extendedMetaInfo=metaInfoBuilder.build();
+
+    return new ImmutableOntology<T, R>(extendedMetaInfo, subGraph, subOntologyRoot,intersectingTerms,
       Sets.intersection(obsoleteTermIds, childTermIds), subsetTermMap, relationBuilder.build());
   }
 

--- a/ontolib-core/src/test/java/com/github/phenomics/ontolib/ontology/data/ImmutableOntologyTest.java
+++ b/ontolib-core/src/test/java/com/github/phenomics/ontolib/ontology/data/ImmutableOntologyTest.java
@@ -2,8 +2,11 @@ package com.github.phenomics.ontolib.ontology.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
+
+import java.util.Map;
 
 public class ImmutableOntologyTest extends ImmutableOntologyTestBase {
 
@@ -35,5 +38,44 @@ public class ImmutableOntologyTest extends ImmutableOntologyTestBase {
         "[ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000002], ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000003], ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000004]]",
         ontology.getParentTermIds(id1).toString());
   }
+
+  /**
+   * The subontology defined by Term with id4 should consist of only the terms id4 and id1.
+   * The termmap should thus contain only two terms. The subontology does not contain the original root of the ontology, id5.
+   */
+  @Test
+  public void testSubontologyCreation() {
+    ImmutableOntology<TestTerm, TestTermRelation> subontology=(ImmutableOntology<TestTerm, TestTermRelation>)ontology.subOntology(id4);
+    assertTrue(subontology.getTermMap().containsKey(id4));
+    assertTrue(subontology.getTermMap().containsKey(id1));
+    assertTrue(ontology.getTermMap().size()==5);
+    assertTrue(subontology.getTermMap().size()==2);
+    assertFalse(subontology.getTermMap().containsKey(id5));
+  }
+
+  /**
+   * The parent ontology has six relations
+   * 1  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000001], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000002], id=1]
+   2  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000001], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000003], id=2]
+   3  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000001], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000004], id=3]
+   4  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000002], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000005], id=4]
+   5  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000003], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000005], id=5]
+   6  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000004], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000005], id=6]
+    The subontology has just the terms id1 and id4, and thus should just have only one relation./subontology
+   3  TestTermRelation [source=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000001], dest=ImmutableTermId [prefix=ImmutableTermPrefix [value=HP], id=0000004], id=3]
+   */
+  @Test
+  public void testSubontologyRelations() {
+    ImmutableOntology<TestTerm, TestTermRelation> subontology=(ImmutableOntology<TestTerm, TestTermRelation>)ontology.subOntology(id4);
+    Map<Integer, TestTermRelation> relationMap = ontology.getRelationMap();
+    int expectedSize=6;
+    assertEquals(expectedSize,relationMap.size());
+    relationMap = subontology.getRelationMap();
+    expectedSize=1;
+    assertEquals(expectedSize,relationMap.size());
+  }
+
+
+
 
 }


### PR DESCRIPTION
I have added code that makes the TermMap and the ReleationMap of subontologies created with the function subOntology in ImmuntableOntology   containly only there terms and relations of the suibontology (previously, they contained the terms of the original ontology). I have added a line to the metadata that says that the ontology was subsetted.